### PR TITLE
Add Poland — Polish Public Tenders Dataset (BZP + TED)

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Lots of entries taken from https://github.com/awesomedata/awesome-public-dataset
 * [Palo Alto, California, US](http://data.cityofpaloalto.org/home)
 * [Philadelphia, US - OpenDataPhilly is a catalog of open data in the](https://www.opendataphilly.org/)
 * [Portland, Oregon](https://www.portlandoregon.gov/28130)
+* [Poland - Polish Public Tenders Dataset (BZP + TED) — ~1.4M public procurement notices from the Polish national procurement bulletin and the EU-wide TED database, with anonymized natural-person contractors. Parquet + CSV, CC BY 4.0, CITATION.cff included.](https://github.com/atlasprzetargow/polish-tenders-dataset)
 * [Portugal - Pordata organization](http://www.pordata.pt/en/Home)
 * [Puerto Rico Government](https://data.pr.gov//)
 * [Quebec City, QC, Canada](http://donnees.ville.quebec.qc.ca/)


### PR DESCRIPTION
## Summary

Adds a new **Government** entry: the **Polish Public Tenders Dataset (BZP + TED)**.

**Repo:** <https://github.com/atlasprzetargow/polish-tenders-dataset>

- **Category:** Government
- **Coverage:** 2024–present, Poland (all 16 voivodeships / NUTS-2 regions)
- **Size:** ~1.4M tender notices · 23k buyer profiles · 82k contractor profiles
- **Sources:** BZP (ezamowienia.gov.pl — Polish national procurement bulletin) + TED (ted.europa.eu — EU-wide procurement database)
- **Format:** Parquet (git-tracked) + gzipped CSV (release assets)
- **License:** CC BY 4.0 (data), MIT (code), CITATION.cff included

## Why this fits

No existing entry in awesome-open-data covers Polish public procurement, which is a ~300 bln PLN/year market. Relevant for:

- Economics research (competition, pricing, market concentration)
- Public-sector transparency work
- ML baselines (CPV category prediction, value estimation)
- Data journalism and investigative reporting

## Compliance

Natural-person contractors (CEIDG sole proprietors) are anonymized via a stable salted SHA-256 hash to comply with Polish/EU data-protection law (RODO/GDPR). Buyers are not anonymized — they're public bodies by law. Full methodology in the [schema docs](https://github.com/atlasprzetargow/polish-tenders-dataset/blob/main/schema/tenders.md#anonymization); detection code is open-source under MIT in [`pii_utils.py`](https://github.com/atlasprzetargow/polish-tenders-dataset/blob/main/pii_utils.py).

Entry inserted between Portland, Oregon and Portugal alphabetically. Thanks for maintaining this list!