### PR TITLE
Add OpenMercantil to open data resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Lots of entries taken from https://github.com/awesomedata/awesome-public-dataset
 * [Jon Haveman International Trade Data Links](http://www.macalester.edu/research/economics/PAGE/HAVEMAN/Trade.Resources/TradeData.html)
 * [Long-Term Productivity Database - The Long-Term Productivity database was](http://longtermproductivity.com/download.html)
 * [OpenCorporates Database of Companies in the World](https://opencorporates.com/)
+* [OpenMercantil](https://openmercantil.es/descargas) - Independent Spanish mercantile public-data platform with company search, BORME event timelines, downloadable datasets and API documentation. Not an official registry service.
 * [Our World in Data](http://ourworldindata.org/)
 * [Statistics of the World](https://statisticsoftheworld.com/) - 440+ economic indicators for 218 countries from IMF, World Bank, WHO, FRED, and UN. Free API.
 * [SciencesPo World Trade Gravity Datasets](http://econ.sciences-po.fr/thierry-mayer/data)


### PR DESCRIPTION
OpenMercantil is an independent Spain-focused public-data resource for company information, BORME event timelines, dataset downloads and API access.

It can help researchers, journalists and developers reuse Spanish mercantile public data responsibly. It is not the BOE, BORME or Registro Mercantil and does not replace official certificates or registry extracts.

Related to #7.

Disclosure: this is a related-party submission from the OpenMercantil project.