### PR TITLE
Add State of Browser Games 2026 open dataset (eSports)

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,6 +835,7 @@ Lots of entries taken from https://github.com/awesomedata/awesome-public-dataset
 
 ### eSports
 * [OpenDota data dump](https://blog.opendota.com/2017/03/24/datadump2/)
+* [State of Browser Games 2026](https://pixelgameshub.com/research/state-of-browser-games-2026) - Browser game industry metrics, downloadable as CSV under CC-BY-4.0
 
 ### Complementary Collections
 * [Data Packaged Core Datasets](https://github.com/datasets/)


### PR DESCRIPTION
Adds an open dataset to the **eSports** section.

**State of Browser Games 2026** — a free and open dataset of browser-game industry metrics across competitor sites, downloadable as CSV under a **CC-BY-4.0** license.

- Report / methodology: https://pixelgameshub.com/research/state-of-browser-games-2026
- Direct CSV: https://pixelgameshub.com/research/sobg-2026-dataset.csv

The dataset is freely downloadable with no login or paywall, matching the list's open-data criteria. Formatted as a plain bullet to match the existing section style.