### PR TITLE
Add Padel Snipe padel clubs atlas to Sports

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,6 +790,7 @@ Lots of entries taken from https://github.com/awesomedata/awesome-public-dataset
 * [Ergast Formula 1, from 1950 up to date (API)](http://ergast.com/mrd/db)
 * [Football/Soccer resources (data and APIs)](http://www.jokecamp.com/blog/guide-to-football-and-soccer-data-and-apis/)
 * [Lahman's Baseball Database](http://www.seanlahman.com/baseball-archive/statistics/)
+* [Padel Snipe - open atlas of 4,000+ padel clubs across 9 European countries with GPS and courts (API)](https://padelsnipe.com/fr/world/api)
 * [Pinhooker: Thoroughbred Bloodstock Sale Data](https://github.com/phillc73/pinhooker)
 * [Pro Kabadi season 1 to 7 - Pro Kabadi League is a professional-level](https://github.com/ranganadhkodali/Pro-Kabadi-season-1-7-Stats)
 * [Retrosheet Baseball Statistics](http://www.retrosheet.org/game.htm)


### PR DESCRIPTION
Adds **Padel Snipe** to the Sports section.

Open atlas of 4,000+ mapped padel clubs across 9 European countries (GPS coordinates, city, indoor/outdoor court counts). Free JSON API, no auth, CORS open. License CC-BY 4.0, also listed on data.gouv.fr. Single bullet added.