### PR TITLE
Add BrightKey education dataset under Education

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Lots of entries taken from https://github.com/awesomedata/awesome-public-dataset
 * [New York State Education Department Data - The New York State Education](https://data.nysed.gov/downloads.php)
 * [Student Data from Free Code Camp](https://github.com/freeCodeCamp/open-data)
 * [Stanford Open Data Portal](https://opendata.stanforddaily.com/#/)
+* [BrightKey University & International School Ratings](https://brightkey.co/en/rankings/dataset) - Independent CC-BY-4.0 dataset rating ~299 universities and ~184 international schools across six dimensions (also on Hugging Face, Kaggle, Zenodo).
 
 ### Energy
 * [AMPds - The Almanac of Minutely Power dataset](http://ampds.org/)


### PR DESCRIPTION
Adds an open CC-BY-4.0 education dataset under the Education section: BrightKey independent ratings of ~299 universities and ~184 international schools across six dimensions. Freely downloadable (Hugging Face, Kaggle, Zenodo DOI 10.5281/zenodo.20603841). Homepage: https://brightkey.co/en/rankings/dataset