### PR TITLE
Add US County AirData 5-Year Emission Trends

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Lots of entries taken from https://github.com/awesomedata/awesome-public-dataset
 * [UEA Climatic Research Unit](http://www.cru.uea.ac.uk/data)
 * [WU Historical Weather Worldwide](https://www.wunderground.com/history/index.html)
 * [WorldClim - Global Climate Data](http://www.worldclim.org)
+* [US County AirData 5-Year Emission Trends - facility-reported air emission change for 994 US counties (EPA AirData 2020-2024, CC BY 4.0)](https://doi.org/10.5281/zenodo.20382474)
 
 ### Complex networks
 * [AMiner Citation Network Dataset](http://aminer.org/citation)


### PR DESCRIPTION
Adds one entry to Climate and Weather.

**US County AirData 5-Year Emission Trends** - five-year change classification (decrease / increase / stable / insufficient_data) of facility-reported air emissions for 994 US counties, derived from EPA AirData annual county AQI summaries 2020-2024. Keyed by FIPS; each record carries the signed percent change, cycles used, facility count, a sensitivity flag, and the latest AQI year.

Two properties that matter for how it should be read:

- These are **facility-reported emissions, not ambient air quality measurements**. The distinction is stated on every record and in the dataset README.
- Counties without a robust signal are **marked, not dropped**: where the change is withheld (too few reporting facilities, or a petrochemical-corridor hold), the record carries an explicit skip_reason and change_class = insufficient_data instead of being silently omitted. 375 of the 994 counties fall in that class.

Formats: JSON and CSV. Also on npm and PyPI as `us-county-airdata-trends`. License CC BY 4.0, archived on Zenodo with a DOI.