### PR TITLE
Add US Vehicle Reliability (NHTSA complaints & recalls) to Transportation

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,7 @@ Lots of entries taken from https://github.com/awesomedata/awesome-public-dataset
 
 ### Transportation
 * [Airlines OD Data 1987-2008](http://stat-computing.org/dataexpo/2009/the-data.html)
+* [US Vehicle Reliability - NHTSA owner complaints & recalls, MY 2005-2026 (CC BY 4.0)](https://huggingface.co/ProblemsByVin)
 * [Ford GoBike Data (formerly Bay Area Bike Share Data)](https://www.fordgobike.com/system-data)
 * [Bike Share Systems (BSS) collection](https://github.com/BetaNYC/Bike-Share-Data-Best-Practices/wiki/Bike-Share-Data-Systems)
 * [Dutch Traffic Information](https://www.ndw.nu/en/)


### PR DESCRIPTION
Adds ProblemsByVin's open NHTSA vehicle-reliability datasets to the Transportation section — free CSV downloads under CC BY 4.0, no login, hosted on Hugging Face. Derived from the public US NHTSA owner-complaint and recall record (failure-mileage quartiles, recall gaps, engine/transmission complaint density, per-vehicle reliability scorecard).