### PR TITLE
Add BottleneckPC PC hardware dataset to eSports

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,7 @@ Lots of entries taken from https://github.com/awesomedata/awesome-public-dataset
 ### eSports
 * [OpenDota data dump](https://blog.opendota.com/2017/03/24/datadump2/)
 * [State of Browser Games 2026](https://pixelgameshub.com/research/state-of-browser-games-2026) - Browser game industry metrics, downloadable as CSV under CC-BY-4.0
+* [BottleneckPC PC Hardware Dataset](https://bottleneckpc.com/data) - Specs and gaming-performance scores for 300+ CPUs and 140+ GPUs, JSON download, CC-BY-4.0
 
 ### Complementary Collections
 * [Data Packaged Core Datasets](https://github.com/datasets/)


### PR DESCRIPTION
Adds the BottleneckPC open hardware dataset: specs and calibrated gaming-performance scores for 300+ CPUs and 140+ GPUs, downloadable as JSON directly (no login) at https://bottleneckpc.com/data.json, licensed CC BY 4.0 and refreshed monthly.