### PR TITLE
Add DNA Chip Coverage dataset to Biology

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Lots of entries taken from https://github.com/awesomedata/awesome-public-dataset
 * [Broad Cancer Cell Line Encyclopedia (CCLE)](http://www.broadinstitute.org/ccle/home)
 * [Cell Image Library](http://www.cellimagelibrary.org)
 * [Complete Genomics Public Data - A diverse data set of whole human genomes](http://www.completegenomics.com/public-data/69-genomes/)
+* [DNA Chip Coverage](https://github.com/AndreySoloviev/dna-chip-coverage) - Which SNP markers are present on consumer DNA genotyping arrays: 70 clinically discussed markers against 5 published Illumina arrays and 9 consumer products (980 rows), built from public Illumina manifests and dbSNP coordinates with a reproducible build script, CSV, CC BY 4.0
 * [EBI ArrayExpress - ArrayExpress Archive of Functional Genomics Data](http://www.ebi.ac.uk/arrayexpress/)
 * [EBI Protein Data Bank in Europe - The Electron Microscopy Data Bank](http://www.ebi.ac.uk/pdbe/emdb/index.html/)
 * [ENCODE project - The Encyclopedia of DNA Elements (ENCODE) Consortium](https://www.encodeproject.org)


### PR DESCRIPTION
Adds one entry to **Biology**, inserted alphabetically between Complete Genomics and EBI ArrayExpress.

**What it is:** a table of `SNP marker × consumer DNA genotyping array → present / absent / unknown`. 70 clinically discussed markers against the 5 published Illumina arrays that consumer chips are built on, plus 9 consumer products — 980 rows of CSV.

**Where the data comes from:** public Illumina array manifests and dbSNP coordinates, nothing else. `scripts/build.py` (Python 3.9+, stdlib only, no dependencies) regenerates `coverage.csv` from those sources from scratch, and `SOURCES.md` records a retrieval date for every source.

**Why it's useful:** a consumer DNA raw-data file only contains the markers its array happened to assay, and the file doesn't say which those are — so tools reading it can report a result for a marker that was never measured. Worked example: an APOE ε genotype needs both `rs429358` and `rs7412`; all five arrays carry `rs7412`, exactly one carries `rs429358`. This makes that checkable per marker instead of assumed.

**On scope, to be upfront:** array coverage is an already-studied subject (Verlouw 2021 EJHG, Lemieux Perreault 2018 Pharmacogenomics, and others cited in the README's *Prior work* section) — nothing here is claimed as a new finding. The contribution is that it's a downloadable, queryable table rather than results inside papers. Also, `unknown` is a real value: no vendor publishes a per-chip manifest, so most consumer-chip rows are `unknown` by design rather than filled in with guesses.

**Licence:** data and docs CC BY 4.0; code in `scripts/` MIT. Direct download, no login or paywall. Source manifests are not redistributed — the build script fetches them from the publisher.
