### PR TITLE
Add ENSO Historical Dataset (1950–2026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,3 +872,8 @@ Lots of entries taken from https://github.com/awesomedata/awesome-public-dataset
 * [Shadowbroker: Track everything from the corporate/private jets of the wealthy, and spy satellites, to seismic events in one unified interface.](https://github.com/BigBodyCobain/Shadowbroker)
 ## Contributions welcome
 If you wish to contribute to this list, just fork, make your changes and send me a pull request, I'll be happy to review all of your suggestions :)
+
+
+## Climate & Weather
+
+- [ENSO Historical Dataset](https://github.com/dayu2333-jinyul/enso-historical-data) — Comprehensive monthly ENSO data (1950–2026), 126 records with ONI, SOI, and subsurface temperature anomalies. CSV + JSON, CC0.


### PR DESCRIPTION
Added the ENSO Historical Dataset — comprehensive monthly El Niño Southern Oscillation data covering 8 major events since 1950. 126 records with ONI, SOI, and subsurface temperature anomalies.

- CSV + JSON formats
- CC0 license
- Permanent DOI: 10.5281/zenodo.21717522