### PR TITLE
Add Global Solo Banking Access Index to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Lots of entries taken from https://github.com/awesomedata/awesome-public-dataset
 ### Finance
 * [Blockmodo Coin Registry - A registry of JSON formatted information files](https://github.com/Blockmodo/coin_registry)
 * [CBOE Futures Exchange](http://cfe.cboe.com/market-data/)
+* [Global Solo Banking Access Index](https://www.globalsolo.global/data/banking-access-index) - Which of 18 US business-banking providers accept business owners resident in 8 countries (India, China, Brazil, Turkey, Nigeria, Pakistan, UK, Canada): 144 provider-country pairs coded in four states that keep "no published restriction" separate from acceptance, 239 claims each carrying a verbatim provider quote, source URL and access date, re-verified quarterly, CSV/JSON with evidence appendix, CC BY 4.0, DOI 10.5281/zenodo.21336392
 * [Google Finance](https://www.google.com/finance)
 * [Google Trends](http://www.google.com/trends?q=google&ctab=0&geo=all&date=all&sort=0)
 * [NASDAQ](https://data.nasdaq.com/)


### PR DESCRIPTION
Adds one entry to **Finance**: a free, CC BY 4.0 dataset on US business-banking access by the owner's country of residence.

**[Banking Access Index](https://www.globalsolo.global/data/banking-access-index)** — 18 US business-banking providers × 8 countries (India, China, Brazil, Turkey, Nigeria, Pakistan, UK, Canada) = 144 provider-country pairs, built from 239 claims verified against each provider's own published wording.

Why it may be useful here: the grid is coded in **four** states rather than two, so *"no published restriction"* stays distinct from *"accepts"*. That distinction is the substance of the dataset — 26 pairs have a restriction list the country is simply absent from, and 39 have no published country policy at all, so 45% of the grid is silence of one kind or another, while explicit acceptance appears in only 22 of 144.

- Every cell carries a verbatim provider quote, a source URL and an access date
- CSV + JSON downloads with a full evidence appendix
- CC BY 4.0
- Archived with a DOI: [10.5281/zenodo.21336392](https://doi.org/10.5281/zenodo.21336392)
- Re-verified quarterly under a published SOP (provider policies move; two of our own earlier articles were stale on exactly these cells and the dataset caught it)

Disclosure: I maintain this. Global Solo is funded by affiliate commissions on service comparisons elsewhere on the domain; the Banking Access Index page itself carries no affiliate links, and the data is CC BY so it can be used and cited independently.